### PR TITLE
Update inline assembly to support new syntax

### DIFF
--- a/src/cpucounter.c
+++ b/src/cpucounter.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+#if defined(__x86_64__) || defined(__amd64__)
 uint64_t cpucounter(void)
 {
     uint64_t low, high;
@@ -9,3 +10,12 @@ uint64_t cpucounter(void)
                          : "%ecx");
     return (high << 32) | low;
 }
+#elif defined(__aarch64__)
+uint64_t cpucounter(void)
+{
+    uint64_t virtual_timer_value;
+    __asm__ __volatile__("mrs %0, cntvct_el0"
+                         : "=r"(virtual_timer_value));
+    return virtual_timer_value;
+}
+#endif

--- a/src/cpucounter.c
+++ b/src/cpucounter.c
@@ -3,6 +3,9 @@
 uint64_t cpucounter(void)
 {
     uint64_t low, high;
-    __asm__ __volatile__ ("rdtscp" : "=a" (low), "=d" (high) : : "%ecx");
+    __asm__ __volatile__("rdtscp"
+                         : "=a"(low), "=d"(high)
+                         :
+                         : "%ecx");
     return (high << 32) | low;
 }

--- a/src/cpucounter.rs
+++ b/src/cpucounter.rs
@@ -8,7 +8,7 @@ pub(crate) struct CPUCounter;
 #[inline]
 unsafe fn cpucounter() -> u64 {
     let (low, high): (u64, u64);
-    llvm_asm!("rdtscp" :  "={eax}" (low), "={edx}" (high) : : "ecx");
+    asm!("rdtscp", out("eax") low, out("edx") high, out("ecx") _);
     (high << 32) | low
 }
 

--- a/src/cpucounter.rs
+++ b/src/cpucounter.rs
@@ -6,10 +6,20 @@ pub(crate) struct CPUCounter;
 
 #[cfg(asm)]
 #[inline]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn cpucounter() -> u64 {
     let (low, high): (u64, u64);
     asm!("rdtscp", out("eax") low, out("edx") high, out("ecx") _);
     (high << 32) | low
+}
+
+#[cfg(asm)]
+#[inline]
+#[cfg(any(target_arch = "aarch64"))]
+unsafe fn cpucounter() -> u64 {
+    let (vtm): (u64);
+    asm!("mrs {}, cntvct_el0", out(reg) vtm);
+    vtm
 }
 
 #[cfg(not(asm))]


### PR DESCRIPTION
@jedisct1 It seems for recent versions of rust the inline assembly syntax currently originally used here is no longer valid (https://github.com/rust-lang/rust/pull/69171). There is a workaround used here that calls for using llvm_asm! instead, but that solution is just renaming the now deprecated syntax and is considered unstable. Also ... oddly a strange compilation error occurred complaining of the llvm_asm syntax when compiling this on Aarch64 for as a sightglass dependency. Perhaps that was my error, but this patch updates to the new syntax and as implied, adds support for ARM.