### PR TITLE
Add RISCV64 implementation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn asm_detect() {
         target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "aarch64",
+        target_arch = "riscv64",
     ));
     if using_nightly && asm_capable_target {
         println!("cargo:rustc-cfg=asm");

--- a/src/cpucounter.c
+++ b/src/cpucounter.c
@@ -18,4 +18,12 @@ uint64_t cpucounter(void)
                          : "=r"(virtual_timer_value));
     return virtual_timer_value;
 }
+#elif defined(__riscv)
+uint64_t cpucounter(void)
+{
+    uint64_t time;
+    __asm__ __volatile__("rdtime %0"
+                         : "=r"(time));
+    return time;
+}
 #endif

--- a/src/cpucounter.rs
+++ b/src/cpucounter.rs
@@ -30,6 +30,15 @@ unsafe fn cpucounter() -> u64 {
     vtm
 }
 
+#[cfg(asm)]
+#[inline]
+#[cfg(target_arch = "riscv64")]
+unsafe fn cpucounter() -> u64 {
+    let time: u64;
+    asm!("rdtime {}", out(reg) time);
+    time
+}
+
 #[cfg(all(not(asm), not(any(target_arch = "wasm32", target_arch = "wasm64"))))]
 extern "C" {
     fn cpucounter() -> u64;


### PR DESCRIPTION
The RISCV64 implementation uses the `rdtime` pseudoinstruction that reads the `time` CSR. That CSR counts wall-clock real time from an arbitrary point in time.

This CSR is available in RV64I (i.e. the base ISA) so it should be available for everyone. See also [Section 10.1 - "Base Counters and Timers"](https://five-embeddev.com/riscv-isa-manual/latest/counters.html#base-counters-and-timers) for more details.