### PR TITLE
Target stable asm! and set MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/jedisct1/rust-precision"
 repository = "https://github.com/jedisct1/rust-precision"
 description = "Low overhead, high precision measurement crate"
 edition = "2018"
+rust-version = "1.59.0"  # inline assembly stabilized
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
 libc = "0.2"
@@ -23,7 +24,6 @@ wasm-bindgen = "0.2"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.build-dependencies]
 cc = "1"
-rustc_version = "0.4"
 
 [features]
 wasi-abi2 = ["dep:wasi-abi2"]

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,12 @@
 #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
-use rustc_version::{version_meta, Channel};
-
-#[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
 fn asm_detect() {
-    let using_nightly = version_meta().unwrap().channel == Channel::Nightly;
     let asm_capable_target = cfg!(any(
         target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "riscv64",
     ));
-    if using_nightly && asm_capable_target {
+    if asm_capable_target {
         println!("cargo:rustc-cfg=asm");
     } else {
         cc::Build::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![allow(stable_features)]
-#![cfg_attr(asm, feature(asm))]
 
 mod config;
 mod cpucounter;


### PR DESCRIPTION
On non-nightly compilers, the precision crate code continued to fallback on the C version; Inline assembly has been stable for some time now, so target it and set the MSRV to 1.59.